### PR TITLE
Fix for deprecated split-window -p flag in tmux 3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,60 @@
 {
   "name": "tmex",
-  "version": "1.0.9",
-  "lockfileVersion": 1,
+  "version": "1.0.10",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "tmex",
+      "version": "1.0.10",
+      "license": "MIT",
+      "bin": {
+        "tmex": "tmex"
+      },
+      "devDependencies": {
+        "bats": "1.2.1",
+        "bats-assert": "2.0.0",
+        "bats-support": "git+https://github.com/ztombol/bats-support.git#v0.2.0",
+        "shellcheck": "0.4.4"
+      }
+    },
+    "node_modules/bats": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.2.1.tgz",
+      "integrity": "sha512-2fcPDRQa/Kvh6j1IcCqsHpT5b9ObMzRzw6abC7Bg298PX8Qdh9VRkvO2WJUEhdyfjq2rLBCOAWdcv0tS4+xTUA==",
+      "dev": true,
+      "bin": {
+        "bats": "bin/bats"
+      }
+    },
+    "node_modules/bats-assert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bats-assert/-/bats-assert-2.0.0.tgz",
+      "integrity": "sha512-qO3kNilWxW8iCONu9NDUfvsCiC6JzL6DPOc/DGq9z3bZ9/A7wURJ+FnFMxGbofOmWbCoy7pVhofn0o47A95qkQ==",
+      "dev": true,
+      "peerDependencies": {
+        "bats-support": "git+https://github.com/ztombol/bats-support.git#v0.2.0"
+      }
+    },
+    "node_modules/bats-support": {
+      "version": "0.2.0",
+      "resolved": "git+ssh://git@github.com/ztombol/bats-support.git#d0a131831c487a1f1141e76d3ab386c89642cdff",
+      "integrity": "sha512-wHzH07tQWsUbZFUmbIjWPhYsfgzmjh4AvReRxSFqipJpACHxMdNnzG6q0LAUHobxaMFVL3UqzxuphHxfAOJpHA==",
+      "dev": true
+    },
+    "node_modules/shellcheck": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/shellcheck/-/shellcheck-0.4.4.tgz",
+      "integrity": "sha512-d7LfrgEcGZes825x5Yehm6MkpfSQaDg4nP0VZEv7E2qX84zQXDbCdDvYJg9V9OByG2+h98Ol7nndixgGOj8cRQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "LICENSE.txt": "shellcheck-latest/LICENSE.txt",
+        "README.txt": "shellcheck-latest/README.txt",
+        "shellcheck": "shellcheck-latest/shellcheck"
+      }
+    }
+  },
   "dependencies": {
     "bats": {
       "version": "1.2.1",
@@ -14,12 +66,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bats-assert/-/bats-assert-2.0.0.tgz",
       "integrity": "sha512-qO3kNilWxW8iCONu9NDUfvsCiC6JzL6DPOc/DGq9z3bZ9/A7wURJ+FnFMxGbofOmWbCoy7pVhofn0o47A95qkQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "bats-support": {
-      "version": "git+https://github.com/ztombol/bats-support.git#d0a131831c487a1f1141e76d3ab386c89642cdff",
-      "from": "git+https://github.com/ztombol/bats-support.git#v0.2.0",
-      "dev": true
+      "version": "git+ssh://git@github.com/ztombol/bats-support.git#d0a131831c487a1f1141e76d3ab386c89642cdff",
+      "dev": true,
+      "from": "bats-support@git+https://github.com/ztombol/bats-support.git#v0.2.0"
     },
     "shellcheck": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "shellcheck tmex",
     "test": "npm run lint && bats test.bats",
+    "testf": "run() { npm run lint && bats -f \"$@\" test.bats; }; run",
     "testn": "clear && npm run test | bats-notify",
     "testw": "npm run test && fswatch -0 -o -r . | xargs -0 -n1 npm run test",
     "testnw": "npm run testn && fswatch -0 -o -r . | xargs -0 -n1 npm run testn"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmex",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A minimalist tmux layout manager - one shell script + tmux +  zero other dependencies",
   "main": "tmex",
   "scripts": {

--- a/test.bats
+++ b/test.bats
@@ -5,879 +5,877 @@ load './node_modules/bats-assert/load'
 
 dir=$BATS_TEST_DIRNAME
 
+ORIGINAL_PATH="$PATH"
+
 setup() {
-  # ensure TMUX_PANE is not set at beginning of test so that tests can be run
-  # from within tmux (TMUX_PANE handling is tested explicitly at end of suite)
-  unset TMUX_PANE
+	# ensure TMUX_PANE is not set at beginning of test so that tests can be run
+	# from within tmux (TMUX_PANE handling is tested explicitly at end of suite)
+	unset TMUX_PANE
+	mock_tmux
 }
 
-@test "./tmex --print" {
-  run $dir/tmex --print
-  assert_output -p "Invalid input: session name required"
-  assert_output -p "Usage:"
-  assert_failure
+teardown() {
+	unset TMUX_PANE
+	restore_tmux
 }
 
-@test "./tmex -p" {
-  run $dir/tmex -p
-  assert_output -p "Invalid input: session name required"
-  assert_output -p "Usage:"
-  assert_failure
+mock_tmux() {
+	mkdir testbin
+	export PATH="./testbin:$PATH"
+	cat <<-EOF > ./testbin/tmux
+		#!/usr/bin/env bash
+		main() {
+			local args
+			local arg
+			local output=""
+			args=( "\${@}" )
+			for (( idx = 0; idx < \${#args[@]}; idx++ )); do
+				arg="\${args[idx]}"
+				if [[ "\${args[idx]}" =~ [[:space:]] ]]; then
+					arg="\${arg//\\"/\\\\\\"}"
+					output+="\\"\${arg}\\" "
+				else
+					output+="\${arg} "
+				fi
+			done
+			echo "\${output}"
+		}
+		main "\${@}"
+	EOF
+	chmod +x ./testbin/tmux
 }
 
-@test "./tmex testsessionname --print" {
-  run $dir/tmex testsessionname --print
-  assert_output -p "new-session -s testsessionname"
-  assert_success
+restore_tmux() {
+	rm -rf testbin
+	export PATH="$ORIGINAL_PATH"
 }
 
-@test "./tmex testsessionname -p" {
-  run $dir/tmex testsessionname -p
-  assert_output -p "new-session -s testsessionname"
-  assert_success
+@test "./tmex" {
+	run $dir/tmex
+	assert_output -p "Invalid input: session name required"
+	assert_output -p "Usage:"
+	assert_failure
+}
+
+@test "./tmex testsessionname" {
+	run $dir/tmex testsessionname
+	assert_output -p "new-session -s testsessionname"
+	assert_success
 }
 
 @test "./tmex --help" {
-  run $dir/tmex --help
-  assert_output -p "Usage:"
-  assert_success
+	run $dir/tmex --help
+	assert_output -p "Usage:"
+	assert_success
 }
 
 @test "./tmex -h" {
-  run $dir/tmex -h
-  assert_output -p "Usage:"
-  assert_success
+	run $dir/tmex -h
+	assert_output -p "Usage:"
+	assert_success
 }
 
 @test "./tmex --version" {
-  run $dir/tmex --version
-  assert_output -p "tmex"
-  assert_success
+	run $dir/tmex --version
+	assert_output -p "tmex"
+	assert_success
 }
 
 @test "./tmex -v" {
-  run $dir/tmex -v
-  assert_output -p "tmex"
-  assert_success
+	run $dir/tmex -v
+	assert_output -p "tmex"
+	assert_success
 }
 
-@test "./tmex --print --npm" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex --print --npm
-  assert_output -p "new-session -s testpackagename"
-  assert_success
-  unset npm_package_name
+@test "./tmex --npm" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex --npm
+	assert_output -p "new-session -s testpackagename"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex -pn" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex -pn
-  assert_output -p "new-session -s testpackagename"
-  assert_success
-  unset npm_package_name
+@test "./tmex -n" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex -n
+	assert_output -p "new-session -s testpackagename"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex testsessionname --print --npm" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex testsessionname --print --npm
-  assert_output -p "new-session -s testsessionname"
-  assert_success
-  unset npm_package_name
+@test "./tmex testsessionname --npm" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex testsessionname --npm
+	assert_output -p "new-session -s testsessionname"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex testsessionname -pn" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex testsessionname -pn
-  assert_output -p "new-session -s testsessionname"
-  assert_success
-  unset npm_package_name
+@test "./tmex testsessionname -n" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex testsessionname -n
+	assert_output -p "new-session -s testsessionname"
+	assert_success
+	unset npm_package_name
 }
 
 function print_layout () {
-  layout="$1"
+	layout="$1"
 
-  IFS=$';'
-  expected=""
-  for command in ${layout}; do
-    command="${command#"${command%%[![:space:]]*}"}"  # remove leading whitespace
-    command="${command%"${command##*[![:space:]]}"}"  # remove trailing whitespace
-    command=$( echo "${command}" | tr -s " " )  # replace multiple space with single
+	IFS=$';'
+	expected=""
+	for command in ${layout}; do
+		command="${command#"${command%%[![:space:]]*}"}"	# remove leading whitespace
+		command="${command%"${command##*[![:space:]]}"}"	# remove trailing whitespace
+		command=$( echo "${command}" | tr -s " " )	# replace multiple space with single
 
-    if [[ "${command}" =~ ^(split-window|select-pane|send-keys) ]]; then
-      expected+="${command}
+		if [[ "${command}" =~ ^(split-window|select-pane|send-keys) ]]; then
+			expected+="${command}
 "
-    fi
-  done
-  unset IFS
+		fi
+	done
+	unset IFS
 
-  echo "${expected}"
+	echo "${expected}"
 }
 
 function assert_layout () {
-  local layout
-  local command
-  local expected
+	local layout
+	local command
+	local expected
 
-  layout="$1"
+	layout="$1"
 
-  IFS=$'\n'
-  expected=""
-  for command in ${layout}; do
-    command="${command#"${command%%[![:space:]]*}"}"  # remove leading whitespace
-    command="${command%"${command##*[![:space:]]}"}"  # remove trailing whitespace
-    command=$( echo "${command}" | tr -s " " )  # replace multiple space with single
-    if [[ -n "${command}" ]]; then
-      expected+="${command} ; "
-    fi
-  done
-  suffix=" ; "
-  expected="${expected%${suffix}}"  # remove trailing semicolon
-  unset IFS
+	IFS=$'\n'
+	expected=""
+	for command in ${layout}; do
+		command="${command#"${command%%[![:space:]]*}"}"	# remove leading whitespace
+		command="${command%"${command##*[![:space:]]}"}"	# remove trailing whitespace
+		command=$( echo "${command}" | tr -s " " )	# replace multiple space with single
+		if [[ -n "${command}" ]]; then
+			expected+="${command} ; "
+		fi
+	done
+	suffix=" ; "
+	expected="${expected%${suffix}}"	# remove trailing semicolon
+	unset IFS
 
-  assert_output -p "${expected}"
+	assert_output -p "${expected}"
 }
 
 layout_1234="
-  split-window -h -p50
-   select-pane -L
-  split-window -h -p50
-   select-pane -R
-  split-window -h -p50
-   select-pane -L
-   select-pane -L
-   select-pane -L
-   select-pane -R
-  split-window -v -p50
-   select-pane -R
-  split-window -v -p67
-  split-window -v -p50
-   select-pane -R
-  split-window -v -p50
-   select-pane -U
-  split-window -v -p50
-   select-pane -D
-  split-window -v -p50
+	split-window -h -p50
+	 select-pane -L
+	split-window -h -p50
+	 select-pane -R
+	split-window -h -p50
+	 select-pane -L
+	 select-pane -L
+	 select-pane -L
+	 select-pane -R
+	split-window -v -p50
+	 select-pane -R
+	split-window -v -p67
+	split-window -v -p50
+	 select-pane -R
+	split-window -v -p50
+	 select-pane -U
+	split-window -v -p50
+	 select-pane -D
+	split-window -v -p50
 "
 
-@test "./tmex testsessionname -p 1234" {
-  run $dir/tmex testsessionname -p 1234
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_1234}"
-  assert_success
+@test "./tmex testsessionname 1234" {
+	run $dir/tmex testsessionname 1234
+	assert_output -p "new-session -s testsessionname"
+	assert_layout "${layout_1234}"
+	assert_success
 }
 
-@test "./tmex testsessionname -p -l1234" {
-  run $dir/tmex testsessionname -p -l1234
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_1234}"
-  assert_success
+@test "./tmex testsessionname -l1234" {
+	run $dir/tmex testsessionname -l1234
+	assert_output -p "new-session -s testsessionname"
+	assert_layout "${layout_1234}"
+	assert_success
 }
 
-@test "./tmex testsessionname -p -l 1234" {
-  run $dir/tmex testsessionname -p -l 1234
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_1234}"
-  assert_success
+@test "./tmex testsessionname -l 1234" {
+	run $dir/tmex testsessionname -l 1234
+	assert_output -p "new-session -s testsessionname"
+	assert_layout "${layout_1234}"
+	assert_success
 }
 
-@test "./tmex testsessionname -l1234 -p" {
-  run $dir/tmex testsessionname -l1234 -p
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_1234}"
-  assert_success
+@test "./tmex testsessionname --layout=1234" {
+	run $dir/tmex testsessionname --layout=1234
+	assert_output -p "new-session -s testsessionname"
+	assert_layout "${layout_1234}"
+	assert_success
 }
 
-@test "./tmex testsessionname -l 1234 -p" {
-  run $dir/tmex testsessionname -l 1234 -p
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_1234}"
-  assert_success
-}
-
-@test "./tmex testsessionname -p --layout=1234" {
-  run $dir/tmex testsessionname -p --layout=1234
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_1234}"
-  assert_success
-}
-
-@test "./tmex testsessionname -p --layout 1234" {
-  run $dir/tmex testsessionname -p --layout 1234
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_1234}"
-  assert_success
+@test "./tmex testsessionname --layout 1234" {
+	run $dir/tmex testsessionname --layout 1234
+	assert_output -p "new-session -s testsessionname"
+	assert_layout "${layout_1234}"
+	assert_success
 }
 
 layout_1234_transposed="
-  split-window -v -p50
-   select-pane -U
-  split-window -v -p50
-   select-pane -D
-  split-window -v -p50
-   select-pane -U
-   select-pane -U
-   select-pane -U
-   select-pane -D
-  split-window -h -p50
-   select-pane -D
-  split-window -h -p67
-  split-window -h -p50
-   select-pane -D
-  split-window -h -p50
-   select-pane -L
-  split-window -h -p50
-   select-pane -R
-  split-window -h -p50
+	split-window -v -p50
+	 select-pane -U
+	split-window -v -p50
+	 select-pane -D
+	split-window -v -p50
+	 select-pane -U
+	 select-pane -U
+	 select-pane -U
+	 select-pane -D
+	split-window -h -p50
+	 select-pane -D
+	split-window -h -p67
+	split-window -h -p50
+	 select-pane -D
+	split-window -h -p50
+	 select-pane -L
+	split-window -h -p50
+	 select-pane -R
+	split-window -h -p50
 "
 
-@test "./tmex testsessionname -pt 1234" {
-  run $dir/tmex testsessionname -pt 1234
-  assert_layout "${layout_1234_transposed}"
-  assert_success
+@test "./tmex testsessionname -t 1234" {
+	run $dir/tmex testsessionname -t 1234
+	assert_layout "${layout_1234_transposed}"
+	assert_success
 }
 
-@test "./tmex testsessionname -p -l1234 -t" {
-  run $dir/tmex testsessionname -p -l1234 -t
-  assert_layout "${layout_1234_transposed}"
-  assert_success
+@test "./tmex testsessionname -l1234 -t" {
+	run $dir/tmex testsessionname -l1234 -t
+	assert_layout "${layout_1234_transposed}"
+	assert_success
 }
 
-@test "./tmex testsessionname --print --layout=1234 --transpose" {
-  run $dir/tmex testsessionname --print --layout=1234 --transpose
-  assert_layout "${layout_1234_transposed}"
-  assert_success
+@test "./tmex testsessionname --layout=1234 --transpose" {
+	run $dir/tmex testsessionname --layout=1234 --transpose
+	assert_layout "${layout_1234_transposed}"
+	assert_success
 }
 
 layout_123456="
-  split-window -h -p67
-  split-window -h -p50
-   select-pane -L
-   select-pane -L
-   select-pane -R
-  split-window -v -p50
-   select-pane -U
-  split-window -h -p57
-   select-pane -D
-  split-window -h -p80
-  split-window -h -p50
-   select-pane -L
-  split-window -h -p50
-   select-pane -R
-  split-window -h -p50
-   select-pane -R
-  split-window -v -p50
-   select-pane -U
-  split-window -v -p67
-  split-window -v -p50
-   select-pane -D
-  split-window -v -p67
-  split-window -v -p50
+	split-window -h -p67
+	split-window -h -p50
+	 select-pane -L
+	 select-pane -L
+	 select-pane -R
+	split-window -v -p50
+	 select-pane -U
+	split-window -h -p57
+	 select-pane -D
+	split-window -h -p80
+	split-window -h -p50
+	 select-pane -L
+	split-window -h -p50
+	 select-pane -R
+	split-window -h -p50
+	 select-pane -R
+	split-window -v -p50
+	 select-pane -U
+	split-window -v -p67
+	split-window -v -p50
+	 select-pane -D
+	split-window -v -p67
+	split-window -v -p50
 "
 
-@test "./tmex testsessionname -p 1[2{34}5]6" {
-  run $dir/tmex testsessionname -p 1[2{34}5]6
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_123456}"
-  assert_success
+@test "./tmex testsessionname 1[2{34}5]6" {
+	run $dir/tmex testsessionname 1[2{34}5]6
+	assert_output -p "new-session -s testsessionname"
+	assert_layout "${layout_123456}"
+	assert_success
 }
 
-@test "./tmex testsessionname -p -l1[2{34}5]6" {
-  run $dir/tmex testsessionname -p -l1[2{34}5]6
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_123456}"
-  assert_success
+@test "./tmex testsessionname -l1[2{34}5]6" {
+	run $dir/tmex testsessionname -l1[2{34}5]6
+	assert_output -p "new-session -s testsessionname"
+	assert_layout "${layout_123456}"
+	assert_success
 }
 
-@test "./tmex testsessionname -p -l 1[2{34}5]6" {
-  run $dir/tmex testsessionname -p -l 1[2{34}5]6
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_123456}"
-  assert_success
+@test "./tmex testsessionname -l 1[2{34}5]6" {
+	run $dir/tmex testsessionname -l 1[2{34}5]6
+	assert_output -p "new-session -s testsessionname"
+	assert_layout "${layout_123456}"
+	assert_success
 }
 
-@test "./tmex testsessionname -l1[2{34}5]6 -p" {
-  run $dir/tmex testsessionname -l1[2{34}5]6 -p
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_123456}"
-  assert_success
+@test "./tmex testsessionname --layout=1[2{34}5]6" {
+	run $dir/tmex testsessionname --layout=1[2{34}5]6
+	assert_output -p "new-session -s testsessionname"
+	assert_layout "${layout_123456}"
+	assert_success
 }
 
-@test "./tmex testsessionname -l 1[2{34}5]6 -p" {
-  run $dir/tmex testsessionname -l 1[2{34}5]6 -p
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_123456}"
-  assert_success
-}
-
-@test "./tmex testsessionname -p --layout=1[2{34}5]6" {
-  run $dir/tmex testsessionname -p --layout=1[2{34}5]6
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_123456}"
-  assert_success
-}
-
-@test "./tmex testsessionname -p --layout 1[2{34}5]6" {
-  run $dir/tmex testsessionname -p --layout 1[2{34}5]6
-  assert_output -p "new-session -s testsessionname"
-  assert_layout "${layout_123456}"
-  assert_success
+@test "./tmex testsessionname --layout 1[2{34}5]6" {
+	run $dir/tmex testsessionname --layout 1[2{34}5]6
+	assert_output -p "new-session -s testsessionname"
+	assert_layout "${layout_123456}"
+	assert_success
 }
 
 layout_123456_transposed="
-  split-window -v -p67
-  split-window -v -p50
-   select-pane -U
-   select-pane -U
-   select-pane -D
-  split-window -h -p50
-   select-pane -L
-  split-window -v -p57
-   select-pane -R
-  split-window -v -p80
-  split-window -v -p50
-   select-pane -U
-  split-window -v -p50
-   select-pane -D
-  split-window -v -p50
-   select-pane -D
-  split-window -h -p50
-   select-pane -L
-  split-window -h -p67
-  split-window -h -p50
-   select-pane -R
-  split-window -h -p67
-  split-window -h -p50
+	split-window -v -p67
+	split-window -v -p50
+	 select-pane -U
+	 select-pane -U
+	 select-pane -D
+	split-window -h -p50
+	 select-pane -L
+	split-window -v -p57
+	 select-pane -R
+	split-window -v -p80
+	split-window -v -p50
+	 select-pane -U
+	split-window -v -p50
+	 select-pane -D
+	split-window -v -p50
+	 select-pane -D
+	split-window -h -p50
+	 select-pane -L
+	split-window -h -p67
+	split-window -h -p50
+	 select-pane -R
+	split-window -h -p67
+	split-window -h -p50
 "
 
-@test "./tmex testsessionname -pt 1[2{34}5]6" {
-  run $dir/tmex testsessionname -pt 1[2{34}5]6
-  assert_layout "${layout_123456_transposed}"
-  assert_success
+@test "./tmex testsessionname -t 1[2{34}5]6" {
+	run $dir/tmex testsessionname -t 1[2{34}5]6
+	assert_layout "${layout_123456_transposed}"
+	assert_success
 }
 
-@test "./tmex testsessionname -p -l1[2{34}5]6 -t" {
-  run $dir/tmex testsessionname -p -l1[2{34}5]6 -t
-  assert_layout "${layout_123456_transposed}"
-  assert_success
+@test "./tmex testsessionname -l1[2{34}5]6 -t" {
+	run $dir/tmex testsessionname -l1[2{34}5]6 -t
+	assert_layout "${layout_123456_transposed}"
+	assert_success
 }
 
-@test "./tmex testsessionname --print --layout=1[2{34}5]6 --transpose" {
-  run $dir/tmex testsessionname --print --layout=1[2{34}5]6 --transpose
-  assert_layout "${layout_123456_transposed}"
-  assert_success
+@test "./tmex testsessionname --layout=1[2{34}5]6 --transpose" {
+	run $dir/tmex testsessionname --layout=1[2{34}5]6 --transpose
+	assert_layout "${layout_123456_transposed}"
+	assert_success
 }
 
 layout_44="
-   send-keys a Enter
+	 send-keys a Enter
 split-window -h -p50
-   send-keys e Enter
+	 send-keys e Enter
  select-pane -L
 split-window -v -p50
-   send-keys c Enter
+	 send-keys c Enter
  select-pane -U
 split-window -v -p50
-   send-keys b Enter
+	 send-keys b Enter
  select-pane -D
 split-window -v -p50
-   send-keys d Enter
+	 send-keys d Enter
  select-pane -R
 split-window -v -p50
-   send-keys g Enter
+	 send-keys g Enter
  select-pane -U
 split-window -v -p50
-   send-keys f Enter
+	 send-keys f Enter
  select-pane -D
 split-window -v -p50
-   send-keys h Enter
+	 send-keys h Enter
 "
 
-@test "./tmex testsessionname -p -l=44 a b c d e f g h" {
-  run $dir/tmex testsessionname -p -l=44 a b c d e f g h
-  assert_layout "${layout_44}"
-  assert_success
+@test "./tmex testsessionname -l=44 a b c d e f g h" {
+	run $dir/tmex testsessionname -l=44 a b c d e f g h
+	assert_layout "${layout_44}"
+	assert_success
 }
 
 layout_444="
-   send-keys a Enter
+	 send-keys a Enter
 split-window -h -p67
-   send-keys e Enter
+	 send-keys e Enter
 split-window -h -p50
-   send-keys i Enter
+	 send-keys i Enter
  select-pane -L
  select-pane -L
 split-window -v -p50
-   send-keys c Enter
+	 send-keys c Enter
  select-pane -U
 split-window -v -p50
-   send-keys b Enter
+	 send-keys b Enter
  select-pane -D
 split-window -v -p50
-   send-keys d Enter
+	 send-keys d Enter
  select-pane -R
 split-window -v -p50
-   send-keys g Enter
+	 send-keys g Enter
  select-pane -U
 split-window -v -p50
-   send-keys f Enter
+	 send-keys f Enter
  select-pane -D
 split-window -v -p50
-   send-keys h Enter
+	 send-keys h Enter
  select-pane -R
 split-window -v -p50
-   send-keys k Enter
+	 send-keys k Enter
  select-pane -U
 split-window -v -p50
-   send-keys j Enter
+	 send-keys j Enter
  select-pane -D
 split-window -v -p50
-   send-keys l Enter
+	 send-keys l Enter
 "
 
-@test "./tmex testsessionname -p -l=444 a b c d e f g h i j k l" {
-  run $dir/tmex testsessionname -p -l=444 a b c d e f g h i j k l
-  assert_layout "${layout_444}"
-  assert_success
+@test "./tmex testsessionname -l=444 a b c d e f g h i j k l" {
+	run $dir/tmex testsessionname -l=444 a b c d e f g h i j k l
+	assert_layout "${layout_444}"
+	assert_success
 }
 
 # Test Shell-less mode:
 
-@test "./tmex testsessionname -p --shellless a" {
-  run $dir/tmex testsessionname -p --shellless a
-  assert_layout ""
-  assert_success
+@test "./tmex testsessionname --shellless a" {
+	run $dir/tmex testsessionname --shellless a
+	assert_layout ""
+	assert_success
 }
 
-@test "./tmex testsessionname -p --shellless a b" {
-  run $dir/tmex testsessionname -p --shellless a b
-  assert_layout "
-    split-window -h -p50 b
-     select-pane -L
-     select-pane -R
-  "
-  assert_success
+@test "./tmex testsessionname --shellless a b" {
+	run $dir/tmex testsessionname --shellless a b
+	assert_layout "
+		split-window -h -p50 b
+		 select-pane -L
+		 select-pane -R
+	"
+	assert_success
 }
 
-@test "./tmex testsessionname -p --shellless a b c" {
-  run $dir/tmex testsessionname -p --shellless a b c
-  assert_layout "
-    split-window -h -p50 b
-     select-pane -L
-     select-pane -R
-    split-window -v -p50 c
-  "
-  assert_success
+@test "./tmex testsessionname --shellless a b c" {
+	run $dir/tmex testsessionname --shellless a b c
+	assert_layout "
+		split-window -h -p50 b
+		 select-pane -L
+		 select-pane -R
+		split-window -v -p50 c
+	"
+	assert_success
 }
 
-@test "./tmex testsessionname -p --shellless a b c d" {
-  run $dir/tmex testsessionname -p --shellless a b c d
-  assert_layout "
-    split-window -h -p50 c
-     select-pane -L
-    split-window -v -p50 b
-     select-pane -R
-    split-window -v -p50 d
-  "
-  assert_success
+@test "./tmex testsessionname --shellless a b c d" {
+	run $dir/tmex testsessionname --shellless a b c d
+	assert_layout "
+		split-window -h -p50 c
+		 select-pane -L
+		split-window -v -p50 b
+		 select-pane -R
+		split-window -v -p50 d
+	"
+	assert_success
 }
 
-@test "./tmex testsessionname -p --shellless a b c d e" {
-  run $dir/tmex testsessionname -p --shellless a b c d e
-  assert_layout "
-    split-window -h -p67 b
-    split-window -h -p50 d
-     select-pane -L
-     select-pane -L
-     select-pane -R
-    split-window -v -p50 c
-     select-pane -R
-    split-window -v -p50 e
-  "
-  assert_success
+@test "./tmex testsessionname --shellless a b c d e" {
+	run $dir/tmex testsessionname --shellless a b c d e
+	assert_layout "
+		split-window -h -p67 b
+		split-window -h -p50 d
+		 select-pane -L
+		 select-pane -L
+		 select-pane -R
+		split-window -v -p50 c
+		 select-pane -R
+		split-window -v -p50 e
+	"
+	assert_success
 }
 
-@test "./tmex testsessionname -p --shellless a b c d e f" {
-  run $dir/tmex testsessionname -p --shellless a b c d e f
-  assert_layout "
-    split-window -h -p67 c
-    split-window -h -p50 e
-     select-pane -L
-     select-pane -L
-    split-window -v -p50 b
-     select-pane -R
-    split-window -v -p50 d
-     select-pane -R
-    split-window -v -p50 f
-  "
-  assert_success
+@test "./tmex testsessionname --shellless a b c d e f" {
+	run $dir/tmex testsessionname --shellless a b c d e f
+	assert_layout "
+		split-window -h -p67 c
+		split-window -h -p50 e
+		 select-pane -L
+		 select-pane -L
+		split-window -v -p50 b
+		 select-pane -R
+		split-window -v -p50 d
+		 select-pane -R
+		split-window -v -p50 f
+	"
+	assert_success
 }
 
-@test "./tmex testsessionname -p --shellless a b c d e f g" {
-  run $dir/tmex testsessionname -p --shellless a b c d e f g
-  assert_layout "
-    split-window -h -p50 d
-     select-pane -L
-    split-window -h -p50 b
-     select-pane -R
-    split-window -h -p50 f
-     select-pane -L
-     select-pane -L
-     select-pane -L
-     select-pane -R
-    split-window -v -p50 c
-     select-pane -R
-    split-window -v -p50 e
-     select-pane -R
-    split-window -v -p50 g
-  "
-  assert_success
+@test "./tmex testsessionname --shellless a b c d e f g" {
+	run $dir/tmex testsessionname --shellless a b c d e f g
+	assert_layout "
+		split-window -h -p50 d
+		 select-pane -L
+		split-window -h -p50 b
+		 select-pane -R
+		split-window -h -p50 f
+		 select-pane -L
+		 select-pane -L
+		 select-pane -L
+		 select-pane -R
+		split-window -v -p50 c
+		 select-pane -R
+		split-window -v -p50 e
+		 select-pane -R
+		split-window -v -p50 g
+	"
+	assert_success
 }
 
-@test "./tmex testsessionname -p --shellless a b c d e f g h" {
-  run $dir/tmex testsessionname -p --shellless a b c d e f g h
-  assert_layout "
-    split-window -h -p67 c
-    split-window -h -p50 f
-     select-pane -L
-     select-pane -L
-    split-window -v -p50 b
-     select-pane -R
-    split-window -v -p67 d
-    split-window -v -p50 e
-     select-pane -R
-    split-window -v -p67 g
-    split-window -v -p50 h
-  "
-  assert_success
+@test "./tmex testsessionname --shellless a b c d e f g h" {
+	run $dir/tmex testsessionname --shellless a b c d e f g h
+	assert_layout "
+		split-window -h -p67 c
+		split-window -h -p50 f
+		 select-pane -L
+		 select-pane -L
+		split-window -v -p50 b
+		 select-pane -R
+		split-window -v -p67 d
+		split-window -v -p50 e
+		 select-pane -R
+		split-window -v -p67 g
+		split-window -v -p50 h
+	"
+	assert_success
 }
 
-@test "./tmex testsessionname -p --shellless a b c d e f g h i" {
-  run $dir/tmex testsessionname -p --shellless a b c d e f g h i
-  assert_layout "
-    split-window -h -p67 d
-    split-window -h -p50 g
-     select-pane -L
-     select-pane -L
-    split-window -v -p67 b
-    split-window -v -p50 c
-     select-pane -R
-    split-window -v -p67 e
-    split-window -v -p50 f
-     select-pane -R
-    split-window -v -p67 h
-    split-window -v -p50 i
-  "
-  assert_success
+@test "./tmex testsessionname --shellless a b c d e f g h i" {
+	run $dir/tmex testsessionname --shellless a b c d e f g h i
+	assert_layout "
+		split-window -h -p67 d
+		split-window -h -p50 g
+		 select-pane -L
+		 select-pane -L
+		split-window -v -p67 b
+		split-window -v -p50 c
+		 select-pane -R
+		split-window -v -p67 e
+		split-window -v -p50 f
+		 select-pane -R
+		split-window -v -p67 h
+		split-window -v -p50 i
+	"
+	assert_success
 }
 
-@test "./tmex -p --npm a" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex -p --npm a
-  assert_output -p "new-session -s testpackagename"
-  assert_layout "
-       send-keys \"npm run a\" Enter
-  "
-  assert_success
-  unset npm_package_name
+@test "./tmex --npm a" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex --npm a
+	assert_output -p "new-session -s testpackagename"
+	assert_layout "
+			 send-keys \"npm run a\" Enter
+	"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex -p --npm a b" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex -p --npm a b
-  assert_output -p "new-session -s testpackagename"
-  assert_layout "
-       send-keys \"npm run a\" Enter
-    split-window -h -p50
-       send-keys \"npm run b\" Enter
-     select-pane -L
-     select-pane -R
-  "
-  assert_success
-  unset npm_package_name
+@test "./tmex --npm a b" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex --npm a b
+	assert_output -p "new-session -s testpackagename"
+	assert_layout "
+			 send-keys \"npm run a\" Enter
+		split-window -h -p50
+			 send-keys \"npm run b\" Enter
+		 select-pane -L
+		 select-pane -R
+	"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex -p --npm a b c" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex -p --npm a b c
-  assert_output -p "new-session -s testpackagename"
-  assert_layout "
-       send-keys \"npm run a\" Enter
-    split-window -h -p50
-       send-keys \"npm run b\" Enter
-     select-pane -L
-     select-pane -R
-    split-window -v -p50
-       send-keys \"npm run c\" Enter
-  "
-  assert_success
-  unset npm_package_name
+@test "./tmex --npm a b c" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex --npm a b c
+	assert_output -p "new-session -s testpackagename"
+	assert_layout "
+			 send-keys \"npm run a\" Enter
+		split-window -h -p50
+			 send-keys \"npm run b\" Enter
+		 select-pane -L
+		 select-pane -R
+		split-window -v -p50
+			 send-keys \"npm run c\" Enter
+	"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex -p --npm a b c d" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex -p --npm a b c d
-  assert_output -p "new-session -s testpackagename"
-  assert_layout "
-       send-keys \"npm run a\" Enter
-    split-window -h -p50
-       send-keys \"npm run c\" Enter
-     select-pane -L
-    split-window -v -p50
-       send-keys \"npm run b\" Enter
-     select-pane -R
-    split-window -v -p50
-       send-keys \"npm run d\" Enter
-  "
-  assert_success
-  unset npm_package_name
+@test "./tmex --npm a b c d" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex --npm a b c d
+	assert_output -p "new-session -s testpackagename"
+	assert_layout "
+			 send-keys \"npm run a\" Enter
+		split-window -h -p50
+			 send-keys \"npm run c\" Enter
+		 select-pane -L
+		split-window -v -p50
+			 send-keys \"npm run b\" Enter
+		 select-pane -R
+		split-window -v -p50
+			 send-keys \"npm run d\" Enter
+	"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex -p --npm a b c d e" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex -p --npm a b c d e
-  assert_output -p "new-session -s testpackagename"
-  assert_layout "
-       send-keys \"npm run a\" Enter
-    split-window -h -p67
-       send-keys \"npm run b\" Enter
-    split-window -h -p50
-       send-keys \"npm run d\" Enter
-     select-pane -L
-     select-pane -L
-     select-pane -R
-    split-window -v -p50
-       send-keys \"npm run c\" Enter
-     select-pane -R
-    split-window -v -p50
-       send-keys \"npm run e\" Enter
-  "
-  assert_success
-  unset npm_package_name
+@test "./tmex --npm a b c d e" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex --npm a b c d e
+	assert_output -p "new-session -s testpackagename"
+	assert_layout "
+			 send-keys \"npm run a\" Enter
+		split-window -h -p67
+			 send-keys \"npm run b\" Enter
+		split-window -h -p50
+			 send-keys \"npm run d\" Enter
+		 select-pane -L
+		 select-pane -L
+		 select-pane -R
+		split-window -v -p50
+			 send-keys \"npm run c\" Enter
+		 select-pane -R
+		split-window -v -p50
+			 send-keys \"npm run e\" Enter
+	"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex -p --npm a b c d e f" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex -p --npm a b c d e f
-  assert_output -p "new-session -s testpackagename"
-  assert_layout "
-       send-keys \"npm run a\" Enter
-    split-window -h -p67
-       send-keys \"npm run c\" Enter
-    split-window -h -p50
-       send-keys \"npm run e\" Enter
-     select-pane -L
-     select-pane -L
-    split-window -v -p50
-       send-keys \"npm run b\" Enter
-     select-pane -R
-    split-window -v -p50
-       send-keys \"npm run d\" Enter
-     select-pane -R
-    split-window -v -p50
-       send-keys \"npm run f\" Enter
-  "
-  assert_success
-  unset npm_package_name
+@test "./tmex --npm a b c d e f" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex --npm a b c d e f
+	assert_output -p "new-session -s testpackagename"
+	assert_layout "
+			 send-keys \"npm run a\" Enter
+		split-window -h -p67
+			 send-keys \"npm run c\" Enter
+		split-window -h -p50
+			 send-keys \"npm run e\" Enter
+		 select-pane -L
+		 select-pane -L
+		split-window -v -p50
+			 send-keys \"npm run b\" Enter
+		 select-pane -R
+		split-window -v -p50
+			 send-keys \"npm run d\" Enter
+		 select-pane -R
+		split-window -v -p50
+			 send-keys \"npm run f\" Enter
+	"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex -p --npm a b c d e f g" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex -p --npm a b c d e f g
-  assert_output -p "new-session -s testpackagename"
-  assert_layout "
-       send-keys \"npm run a\" Enter
-    split-window -h -p50
-       send-keys \"npm run d\" Enter
-     select-pane -L
-    split-window -h -p50
-       send-keys \"npm run b\" Enter
-     select-pane -R
-    split-window -h -p50
-       send-keys \"npm run f\" Enter
-     select-pane -L
-     select-pane -L
-     select-pane -L
-     select-pane -R
-    split-window -v -p50
-       send-keys \"npm run c\" Enter
-     select-pane -R
-    split-window -v -p50
-       send-keys \"npm run e\" Enter
-     select-pane -R
-    split-window -v -p50
-       send-keys \"npm run g\" Enter
-  "
-  assert_success
-  unset npm_package_name
+@test "./tmex --npm a b c d e f g" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex --npm a b c d e f g
+	assert_output -p "new-session -s testpackagename"
+	assert_layout "
+			 send-keys \"npm run a\" Enter
+		split-window -h -p50
+			 send-keys \"npm run d\" Enter
+		 select-pane -L
+		split-window -h -p50
+			 send-keys \"npm run b\" Enter
+		 select-pane -R
+		split-window -h -p50
+			 send-keys \"npm run f\" Enter
+		 select-pane -L
+		 select-pane -L
+		 select-pane -L
+		 select-pane -R
+		split-window -v -p50
+			 send-keys \"npm run c\" Enter
+		 select-pane -R
+		split-window -v -p50
+			 send-keys \"npm run e\" Enter
+		 select-pane -R
+		split-window -v -p50
+			 send-keys \"npm run g\" Enter
+	"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex -p --npm a b c d e f g h" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex -p --npm a b c d e f g h
-  assert_output -p "new-session -s testpackagename"
-  assert_layout "
-       send-keys \"npm run a\" Enter
-    split-window -h -p67
-       send-keys \"npm run c\" Enter
-    split-window -h -p50
-       send-keys \"npm run f\" Enter
-     select-pane -L
-     select-pane -L
-    split-window -v -p50
-       send-keys \"npm run b\" Enter
-     select-pane -R
-    split-window -v -p67
-       send-keys \"npm run d\" Enter
-    split-window -v -p50
-       send-keys \"npm run e\" Enter
-     select-pane -R
-    split-window -v -p67
-       send-keys \"npm run g\" Enter
-    split-window -v -p50
-       send-keys \"npm run h\" Enter
-  "
-  assert_success
-  unset npm_package_name
+@test "./tmex --npm a b c d e f g h" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex --npm a b c d e f g h
+	assert_output -p "new-session -s testpackagename"
+	assert_layout "
+			 send-keys \"npm run a\" Enter
+		split-window -h -p67
+			 send-keys \"npm run c\" Enter
+		split-window -h -p50
+			 send-keys \"npm run f\" Enter
+		 select-pane -L
+		 select-pane -L
+		split-window -v -p50
+			 send-keys \"npm run b\" Enter
+		 select-pane -R
+		split-window -v -p67
+			 send-keys \"npm run d\" Enter
+		split-window -v -p50
+			 send-keys \"npm run e\" Enter
+		 select-pane -R
+		split-window -v -p67
+			 send-keys \"npm run g\" Enter
+		split-window -v -p50
+			 send-keys \"npm run h\" Enter
+	"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex -p --npm a b c d e f g h i" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex -p --npm a b c d e f g h i
-  assert_output -p "new-session -s testpackagename"
-  assert_layout "
-       send-keys \"npm run a\" Enter
-    split-window -h -p67
-       send-keys \"npm run d\" Enter
-    split-window -h -p50
-       send-keys \"npm run g\" Enter
-     select-pane -L
-     select-pane -L
-    split-window -v -p67
-       send-keys \"npm run b\" Enter
-    split-window -v -p50
-       send-keys \"npm run c\" Enter
-     select-pane -R
-    split-window -v -p67
-       send-keys \"npm run e\" Enter
-    split-window -v -p50
-       send-keys \"npm run f\" Enter
-     select-pane -R
-    split-window -v -p67
-       send-keys \"npm run h\" Enter
-    split-window -v -p50
-       send-keys \"npm run i\" Enter
-  "
-  assert_success
-  unset npm_package_name
+@test "./tmex --npm a b c d e f g h i" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex --npm a b c d e f g h i
+	assert_output -p "new-session -s testpackagename"
+	assert_layout "
+			 send-keys \"npm run a\" Enter
+		split-window -h -p67
+			 send-keys \"npm run d\" Enter
+		split-window -h -p50
+			 send-keys \"npm run g\" Enter
+		 select-pane -L
+		 select-pane -L
+		split-window -v -p67
+			 send-keys \"npm run b\" Enter
+		split-window -v -p50
+			 send-keys \"npm run c\" Enter
+		 select-pane -R
+		split-window -v -p67
+			 send-keys \"npm run e\" Enter
+		split-window -v -p50
+			 send-keys \"npm run f\" Enter
+		 select-pane -R
+		split-window -v -p67
+			 send-keys \"npm run h\" Enter
+		split-window -v -p50
+			 send-keys \"npm run i\" Enter
+	"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex -pn 1234 a b c d e f g h i j" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex -pn 1234 a b c d e f g h i j
-  assert_output -p "new-session -s testpackagename"
-  assert_layout "
-       send-keys \"npm run a\" Enter
-    split-window -h -p50
-       send-keys \"npm run d\" Enter
-     select-pane -L
-    split-window -h -p50
-       send-keys \"npm run b\" Enter
-     select-pane -R
-    split-window -h -p50
-       send-keys \"npm run g\" Enter
-     select-pane -L
-     select-pane -L
-     select-pane -L
-     select-pane -R
-    split-window -v -p50
-       send-keys \"npm run c\" Enter
-     select-pane -R
-    split-window -v -p67
-       send-keys \"npm run e\" Enter
-    split-window -v -p50
-       send-keys \"npm run f\" Enter
-     select-pane -R
-    split-window -v -p50
-       send-keys \"npm run i\" Enter
-     select-pane -U
-    split-window -v -p50
-       send-keys \"npm run h\" Enter
-     select-pane -D
-    split-window -v -p50
-       send-keys \"npm run j\" Enter
-  "
-  assert_success
-  unset npm_package_name
+@test "./tmex -n 1234 a b c d e f g h i j" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex -n 1234 a b c d e f g h i j
+	assert_output -p "new-session -s testpackagename"
+	assert_layout "
+			 send-keys \"npm run a\" Enter
+		split-window -h -p50
+			 send-keys \"npm run d\" Enter
+		 select-pane -L
+		split-window -h -p50
+			 send-keys \"npm run b\" Enter
+		 select-pane -R
+		split-window -h -p50
+			 send-keys \"npm run g\" Enter
+		 select-pane -L
+		 select-pane -L
+		 select-pane -L
+		 select-pane -R
+		split-window -v -p50
+			 send-keys \"npm run c\" Enter
+		 select-pane -R
+		split-window -v -p67
+			 send-keys \"npm run e\" Enter
+		split-window -v -p50
+			 send-keys \"npm run f\" Enter
+		 select-pane -R
+		split-window -v -p50
+			 send-keys \"npm run i\" Enter
+		 select-pane -U
+		split-window -v -p50
+			 send-keys \"npm run h\" Enter
+		 select-pane -D
+		split-window -v -p50
+			 send-keys \"npm run j\" Enter
+	"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex -pn 1[2{34}5]6 a b c d e f g h i j" {
-  export npm_package_name="testpackagename"
-  run $dir/tmex -pn 1[2{34}5]6 a b c d e f g h i j
-  assert_output -p "new-session -s testpackagename"
-  assert_layout "
-       send-keys \"npm run a\" Enter
-    split-window -h -p67
-       send-keys \"npm run b\" Enter
-    split-window -h -p50
-       send-keys \"npm run i\" Enter
-     select-pane -L
-     select-pane -L
-     select-pane -R
-    split-window -v -p50
-       send-keys \"npm run d\" Enter
-     select-pane -U
-    split-window -h -p57
-       send-keys \"npm run c\" Enter
-     select-pane -D
-    split-window -h -p80
-       send-keys \"npm run e\" Enter
-    split-window -h -p50
-       send-keys \"npm run g\" Enter
-     select-pane -L
-    split-window -h -p50
-       send-keys \"npm run f\" Enter
-     select-pane -R
-    split-window -h -p50
-       send-keys \"npm run h\" Enter
-     select-pane -R
-    split-window -v -p50
-     select-pane -U
-    split-window -v -p67
-       send-keys \"npm run j\" Enter
-    split-window -v -p50
-     select-pane -D
-    split-window -v -p67
-    split-window -v -p50
-  "
-  assert_success
-  unset npm_package_name
+@test "./tmex -n 1[2{34}5]6 a b c d e f g h i j" {
+	export npm_package_name="testpackagename"
+	run $dir/tmex -n 1[2{34}5]6 a b c d e f g h i j
+	assert_output -p "new-session -s testpackagename"
+	assert_layout "
+			 send-keys \"npm run a\" Enter
+		split-window -h -p67
+			 send-keys \"npm run b\" Enter
+		split-window -h -p50
+			 send-keys \"npm run i\" Enter
+		 select-pane -L
+		 select-pane -L
+		 select-pane -R
+		split-window -v -p50
+			 send-keys \"npm run d\" Enter
+		 select-pane -U
+		split-window -h -p57
+			 send-keys \"npm run c\" Enter
+		 select-pane -D
+		split-window -h -p80
+			 send-keys \"npm run e\" Enter
+		split-window -h -p50
+			 send-keys \"npm run g\" Enter
+		 select-pane -L
+		split-window -h -p50
+			 send-keys \"npm run f\" Enter
+		 select-pane -R
+		split-window -h -p50
+			 send-keys \"npm run h\" Enter
+		 select-pane -R
+		split-window -v -p50
+		 select-pane -U
+		split-window -v -p67
+			 send-keys \"npm run j\" Enter
+		split-window -v -p50
+		 select-pane -D
+		split-window -v -p67
+		split-window -v -p50
+	"
+	assert_success
+	unset npm_package_name
 }
 
-@test "./tmex -pn 1234 a b c d e f g h i j k" {
-  run $dir/tmex -pn 1234 a b c d e f g h i j k
-  assert_output -p "Invalid input: --layout=1234 is too small for number of commands provided"
+@test "./tmex -n 1234 a b c d e f g h i j k" {
+	run $dir/tmex -n 1234 a b c d e f g h i j k
+	assert_output -p "Invalid input: --layout=1234 is too small for number of commands provided"
 }
 
-@test "./tmex -pn 1[2{34}5]6 a b c d e f g h i j k l m n o" {
-  run $dir/tmex -pn 1[2{34}5]6 a b c d e f g h i j k l m n o
-  assert_output -p "Invalid input: --layout=1[2{34}5]6 is too small for number of commands provided"
+@test "./tmex -n 1[2{34}5]6 a b c d e f g h i j k l m n o" {
+	run $dir/tmex -n 1[2{34}5]6 a b c d e f g h i j k l m n o
+	assert_output -p "Invalid input: --layout=1[2{34}5]6 is too small for number of commands provided"
 }
 
 # ensure nested tmex commands will select and split their current pane
 # instead of spawning a nested tmux session
-@test "TMUX_PANE=%5 ./tmex testsessionname -p a b c" {
-  export TMUX_PANE="%5"
-  run $dir/tmex testsessionname -p a b c
-  refute_output -p "new-session -s testsessionname"
-  assert_output -p "select-window -t %5 ; select-pane -t %5"
-  assert_layout "
-       send-keys a Enter
-    split-window -h -p50
-       send-keys b Enter
-     select-pane -L
-     select-pane -R
-    split-window -v -p50
-       send-keys c Enter
-  "
-  assert_success
-  unset TMUX_PANE
+@test "TMUX_PANE=%5 ./tmex testsessionname a b c" {
+	export TMUX_PANE="%5"
+	run $dir/tmex testsessionname a b c
+	refute_output -p "new-session -s testsessionname"
+	assert_output -p "select-window -t %5 ; select-pane -t %5"
+	assert_layout "
+			 send-keys a Enter
+		split-window -h -p50
+			 send-keys b Enter
+		 select-pane -L
+		 select-pane -R
+		split-window -v -p50
+			 send-keys c Enter
+	"
+	assert_success
+	unset TMUX_PANE
 }

--- a/tmex
+++ b/tmex
@@ -329,6 +329,19 @@ function split1d () {
   local sizesum
   local sizearr
   local percentage
+  local pctprefix
+  local pctsuffix
+
+  # support for percentage values under `split-pane -l<value>%` was added in tmux 3.1
+  # and `split-pane -p<value>` was deprecated (fully removed in tmux 3.4)
+  # see https://github.com/tmux/tmux/blob/master/CHANGES#L663-L665 for details
+  if [[ -z "${tmuxversion}" ]] || (( $( bc -l <<< "${tmuxversion} < 3.1" ) )); then
+    pctprefix="-p"
+    pctsuffix=""
+  else
+    pctprefix="-l"
+    pctsuffix="%"
+  fi
 
   # convert sizing string to sizearr:
   # numpanes: 3, sizing: "123" -> [1, 2, 3]
@@ -362,7 +375,7 @@ function split1d () {
     percentage=$(( 100 - percentage ))  # invert
 
     # split pane down the middle (adjusted according to size array)
-    tmuxargs+=( ";" "split-window" "-${direction}" "-p${percentage}" )
+    tmuxargs+=( ";" "split-window" "-${direction}" "${pctprefix}${percentage}${pctsuffix}" )
     executecmd "${cmds[${half}]-}"
     selectpane "${direction}" "UL" 1
 
@@ -380,7 +393,7 @@ function split1d () {
     percentage=$(( 100 - percentage ))  # invert
 
     # split off first pane (adjusted according to size array)
-    tmuxargs+=( ";" "split-window" "-${direction}" "-p${percentage}" )
+    tmuxargs+=( ";" "split-window" "-${direction}" "${pctprefix}${percentage}${pctsuffix}" )
     executecmd "${cmds[1]-}"
 
     # if more than 2 panes, keep splitting
@@ -551,8 +564,24 @@ function main () {
   local output
 
   local version
+  local tmuxversion
   local usage
   local help
+
+  tmuxversion="$( tmux -V )"
+  if [[ "${tmuxversion}" =~ ([0-9]+(\.[0-9]+)?) ]]; then
+    tmuxversion="${BASH_REMATCH[0]}"
+  elif [[ -z "${TMEX_SUPPRESS_WARNING_PCT_FLAGS:-}" ]]; then
+    echo "Warning: current tmux version could not be determined from"
+    echo "  tmux -V  >>>  \"${tmuxversion}\""
+    echo "This can result in incorrect pane-splitting behavior since tmux has made"
+    echo "backwards-incompatible changes to flags of the split-window command."
+    echo "Please ensure your installation of tmux produces a semver string within"
+    echo "the output of 'tmux -V', or add 'export TMEX_SUPPRESS_WARNING_PCT_FLAGS=1'"
+    echo "to your shell rc file to hide this warning."
+    echo "See https://github.com/tmux/tmux/blob/master/CHANGES#L663-L665 for details."
+    echo
+  fi
 
   version="$( head -n 3 < "$0" | tail -1 )"
   version="${version#\# }"  # remove "# " prefix

--- a/tmex
+++ b/tmex
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# tmex 1.0.9
+# tmex 1.0.10
 
 # sanity - exit on any error; no unbound variables
 set -euo pipefail


### PR DESCRIPTION
Fix for https://github.com/evnp/tmex/issues/7 (thanks @liangkarl!)

It seems tmux has deprecated `split-window -p<value>` in favor of `split-window -l<value>%` in 3.1, fully removing support for `split-window -p<value>` in 3.4:
```
CHANGES FROM 3.0a TO 3.1
* Add support for percentage sizes for resize-pane ("-x 10%"). Also change
  split-window and join-pane -l to accept similar percentages and deprecate the
  -p flag.
```
https://github.com/tmux/tmux/blob/master/CHANGES#L663

This adds a tmux version check, after which `split-window` calls constructed by tmex will use `-l<value>%` if current version is >=3.1, and continue using `-p<value>` if version is <3.1. If tmux version cannot be determined, a warning will be emitted and tmex will continue to use the old `-p` flag.